### PR TITLE
Moved the register routes helper inside the jimber server instead of jimber sdk module

### DIFF
--- a/jimber.go
+++ b/jimber.go
@@ -1,9 +1,6 @@
 package jimber
 
 import (
-	"fmt"
-
-	"github.com/gin-gonic/gin"
 	client "jimber.com/sdk/client"
 	cmd "jimber.com/sdk/cmd"
 	server "jimber.com/sdk/server"
@@ -25,16 +22,8 @@ func NewJimber(host string, port string) *Jimber {
 	}
 	jimber.Server.Storage = storage.NewStorage()
 	jimber.Server.Storage.DB = jimber.Server.Storage.Connect()
-	jimber.Server.Router = gin.Default()
-	jimber.RegisterAPIRoutes()
+	jimber.Server.RegisterAPIRoutes()
 	return jimber
-}
-
-// Register Project routes inside the jim server
-func (jim *Jimber) RegisterAPIRoutes() {
-	api := jim.Server.Router.Group("api") // => api/
-	fmt.Println(api)
-	jim.Server.Api.Projects.RegisterRoutes(jim.Server.Storage.DB, api)
 }
 
 func (jim *Jimber) RunServer() {

--- a/server/api/projects/models.go
+++ b/server/api/projects/models.go
@@ -3,7 +3,7 @@ package server
 import user "jimber.com/sdk/server/api/users"
 
 // / Project represents a project in the database.
-type Projects struct {
+type Project struct {
 	ID          int         `json:"id"`                                 // ID is the unique identifier of the project.
 	Name        string      `json:"name"`                               // Name is the name of the project.
 	Token       string      `json:"token"`                              // Token is the token associated with the project.

--- a/server/api/projects/projects.go
+++ b/server/api/projects/projects.go
@@ -8,10 +8,10 @@ import (
 	"gorm.io/gorm"
 )
 
-func (p *Projects) GetProjects(db *gorm.DB) gin.HandlerFunc {
+func (p *Project) GetProjects(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Retrieving projects
-		var projects []Projects
+		var projects []Project
 		result := db.Find(&projects)
 		if result.Error != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})
@@ -23,9 +23,9 @@ func (p *Projects) GetProjects(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
-func (p *Projects) CreateProject(db *gorm.DB) gin.HandlerFunc {
+func (p *Project) CreateProject(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var project Projects
+		var project Project
 		if err := c.ShouldBindJSON(&project); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project data"})
 			return
@@ -44,6 +44,6 @@ func (p *Projects) CreateProject(db *gorm.DB) gin.HandlerFunc {
 }
 
 // Initialize a new projects struct
-func NewProjects() *Projects {
-	return &Projects{}
+func NewProjects() *Project {
+	return &Project{}
 }

--- a/server/api/projects/projects.go
+++ b/server/api/projects/projects.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Get all registered projects from the database
 func (p *Project) GetProjects(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Retrieving projects
@@ -23,6 +24,7 @@ func (p *Project) GetProjects(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
+// Method to create project record into the database.
 func (p *Project) CreateProject(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var project Project

--- a/server/api/projects/urls.go
+++ b/server/api/projects/urls.go
@@ -9,7 +9,7 @@ import (
 // This function takes two arguments:
 // 1. db: a pointer to the gorm.DB instance.
 // 2. api: the api group to register the routes under.
-func (p *Projects) RegisterRoutes(db *gorm.DB, api *gin.RouterGroup) {
+func (p *Project) RegisterRoutes(db *gorm.DB, api *gin.RouterGroup) {
 	api.GET("/projects", p.GetProjects(db))
 	api.POST("/projects", p.CreateProject(db))
 }

--- a/server/api/users/urls.go
+++ b/server/api/users/urls.go
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// Register the users routes under the api group.
+// This function takes two arguments:
+// 1. db: a pointer to the gorm.DB instance.
+// 2. api: the api group to register the routes under.
+func (u *User) RegisterRoutes(db *gorm.DB, api *gin.RouterGroup) {
+	api.GET("/users", u.GetUsers(db))
+	api.POST("/users", u.CreateUser(db))
+}

--- a/server/api/users/users.go
+++ b/server/api/users/users.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func (p *User) GetUsers(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Retrieving users
+		var users []User
+		result := db.Find(&users)
+		if result.Error != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})
+			return
+		}
+
+		// Return the users as a response
+		c.JSON(http.StatusOK, gin.H{"users": users})
+	}
+}
+
+// Initialize a new User struct
+func NewUser() *User {
+	return &User{}
+}

--- a/server/api/users/users.go
+++ b/server/api/users/users.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// Get all registered users from the database
 func (p *User) GetUsers(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Retrieving users
@@ -19,6 +20,25 @@ func (p *User) GetUsers(db *gorm.DB) gin.HandlerFunc {
 
 		// Return the users as a response
 		c.JSON(http.StatusOK, gin.H{"users": users})
+	}
+}
+
+// Method to create user record into the database.
+func (p *User) CreateUser(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var user User
+		if err := c.ShouldBindJSON(&user); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user data"})
+			return
+		}
+
+		result := db.Create(&user)
+		if result.Error != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
+			return
+		}
+
+		c.JSON(http.StatusCreated, user)
 	}
 }
 

--- a/server/models.go
+++ b/server/models.go
@@ -8,7 +8,7 @@ import (
 )
 
 type APIRequest struct {
-	Projects *projects.Projects
+	Projects *projects.Project
 }
 
 type JimberServer struct {

--- a/server/models.go
+++ b/server/models.go
@@ -4,11 +4,13 @@ import (
 	"github.com/gin-gonic/gin"
 	logger "jimber.com/sdk/cmd/logger"
 	projects "jimber.com/sdk/server/api/projects"
+	users "jimber.com/sdk/server/api/users"
 	storage "jimber.com/sdk/server/database"
 )
 
 type APIRequest struct {
 	Projects *projects.Project
+	Users    *users.User
 }
 
 type JimberServer struct {

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,13 +1,12 @@
 package server
 
-// registerAPIRoutes registers the API endpoints.
-func (srv *JimberServer) registerAPIRoutes() {
-	// api := srv.Router.Group("/api")
-	// srv.projectRoutes(api)
-}
+import (
+	"github.com/gin-gonic/gin"
+)
 
-// Register all project endpoints
-// func (srv *JimberServer) projectRoutes(api *gin.RouterGroup) {
-// 	api.GET("/projects", srv.getProjectsHandler)
-// 	api.POST("/projects", srv.createProjectHandler)
-// }
+// Register Project routes inside the jim server
+func (s *JimberServer) RegisterAPIRoutes() {
+	s.Router = gin.Default()
+	api := s.Router.Group("api") // => api/
+	s.Api.Projects.RegisterRoutes(s.Storage.DB, api)
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -9,4 +9,5 @@ func (s *JimberServer) RegisterAPIRoutes() {
 	s.Router = gin.Default()
 	api := s.Router.Group("api") // => api/
 	s.Api.Projects.RegisterRoutes(s.Storage.DB, api)
+	s.Api.Users.RegisterRoutes(s.Storage.DB, api)
 }


### PR DESCRIPTION
### Description:

This pull request implements the registration route method in the server module, as it is a server-related functionality.

### Changes:

- Moved the register route method from the Jimber SDK module to the server module.
- Updated the necessary imports and dependencies to ensure proper functionality.
- Tested the implementation to ensure it works as expected.

### Related Issues
- https://github.com/Mahmoud-Emad/jimber-sdk/issues/6
- https://github.com/Mahmoud-Emad/jimber-sdk/issues/8
- https://github.com/Mahmoud-Emad/jimber-sdk/issues/11

### Note
This pull request is opened against the development branch, which incorporates the latest changes and updates. It is worth noting that once the following pull request is merged: [pull-5](https://github.com/Mahmoud-Emad/jimber-sdk/pull/5), all future pull requests will be opened against the master branch.